### PR TITLE
add tests, new engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Included adapters are:
 - [jade](http://jade-lang.com)
 - [then-jade](https://github.com/then/then-jade) - for streaming templates
 - [swig](http://paularmstrong.github.io/swig/)
+- [octet](https://github.com/tunnckoCore/octet)
 - html - just returns the file
 
 ## Examples

--- a/engines/octet.js
+++ b/engines/octet.js
@@ -1,0 +1,21 @@
+
+var fs = require('fs')
+var octet = require('octet')
+
+exports.compile = function (filename, options) {
+  var str = fs.readFileSync(filename, 'utf8')
+  
+  return str;
+}
+
+exports.render = function (str, data) {
+  var ret;
+  octet(str, data, function(err, res) {
+    if (err) {
+      ret = err;
+      return;
+    }
+    ret = res;
+  })
+  return ret;
+}

--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
     "bluebird": "2"
   },
   "devDependencies": {
-    "istanbul": "0",
-    "mocha": "1",
+    "istanbul": "*",
+    "mocha": "*",
     "jade": "*",
     "then-jade": "*",
-    "swig": "*"
+    "swig": "*",
+    "octet": "*"
   },
   "scripts": {
-    "test": "mocha --reporter spec",
+    "test": "mocha",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
   },

--- a/test/fixtures/index.jade
+++ b/test/fixtures/index.jade
@@ -1,1 +1,1 @@
-p hi
+p= user.name

--- a/test/fixtures/index.octet
+++ b/test/fixtures/index.octet
@@ -1,0 +1,1 @@
+<p><%this.user.name%></p>

--- a/test/octet.js
+++ b/test/octet.js
@@ -3,28 +3,26 @@ var assert = require('assert')
 
 var templation = require('..')
 
-describe('engines.jade', function () {
+describe('engines.octet', function () {
   var view = templation({
     root: 'test/fixtures'
   })
-  view.use('jade', templation.engines.jade)
+  view.use('octet', templation.engines.octet)
 
   it('should render with an extension', function () {
-    view.render('index.jade', {user: {name: 'hi'}})
-    .then(function (html) {
-      assert.equal(html.trim(), '<p>hi</p>')
+    view.render('index.octet', {user:{name:'Charlike'}}).then(function (html) {
+      assert.equal(html.trim(), '<p>Charlike</p>')
     })
   })
 
   it('should render without an extension', function () {
-    view.render('index', {user: {name: 'hi'}})
-    .then(function (html) {
-      assert.equal(html.trim(), '<p>hi</p>')
+    view.render('index', {user:{name:'Charlike'}}).then(function (html) {
+      assert.equal(html.trim(), '<p>Charlike</p>')
     })
   })
 
   it('should throw if error and you can `.catch` it', function () {
-    view.render('index.jade', {hello: 'hi'})
+    view.render('index', {hello: 'hi'})
     .then().catch(function(err) {
       assert(err instanceof Error)
     })


### PR DESCRIPTION
- add `should throw if error and you can '.catch' it` test for jade and octet, and change a little bit other tests.
  This test case is when you call some locals from template that not exists (not provided) in locals object.
- change mocha version, because of `customFds` deprication
- remove `--reporter spec` (you know why, lol), because it is default in newest versions.
